### PR TITLE
Fix overflow on `pre` elements

### DIFF
--- a/assets/styles/atom.less
+++ b/assets/styles/atom.less
@@ -2,7 +2,7 @@
 
 pre {
   padding: 5px;
-  overflow: scroll;
+  overflow: auto;
 
   font-family: 'Inconsolata', ;
   background-color: @syntax-background-color;


### PR DESCRIPTION
Setting `overflow: scroll` forces scroll bars, where as `overflow: auto`
only applies those when necessary.

What we have now:
![scroll](https://cloud.githubusercontent.com/assets/692459/7221499/202dc2f8-e6a2-11e4-9ed4-10487e79bf48.png)

What this PR makes it look like:
![no-scroll](https://cloud.githubusercontent.com/assets/692459/7221500/2b966046-e6a2-11e4-865d-43d4935abd8a.png)

What this PR looks like when the `pre` is actually overflowing:
![overflow](https://cloud.githubusercontent.com/assets/692459/7221504/3bcd6018-e6a2-11e4-87aa-390709f6d029.png)
